### PR TITLE
Make CSSFX work with Java 9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 jdk: 
-  - oraclejdk8
+  - oraclejdk9

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/fxmisc/cssfx/impl/ApplicationStages.java
+++ b/src/main/java/org/fxmisc/cssfx/impl/ApplicationStages.java
@@ -21,24 +21,27 @@ package org.fxmisc.cssfx.impl;
  */
 
 
+import static java.util.stream.Collectors.toList;
 import static org.fxmisc.cssfx.impl.log.CSSFXLogger.logger;
 
-import java.lang.reflect.Method;
-
+import java.util.stream.Collectors;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 
 public class ApplicationStages {
     public static ObservableList<Stage> monitoredStages(Stage ...restrictedTo) {
         try {
-            Class<?> sh = Class.forName("com.sun.javafx.stage.StageHelper");
-            Method m = sh.getMethod("getStages");
-            ObservableList<Stage> stages = (ObservableList<Stage>) m.invoke(null, new Object[0]);
-            logger(ApplicationStages.class).debug("successfully retrieved JavaFX stages from com.sun.javafx.stage.StageHelper");
+            ObservableList<Stage> stages = Window.getWindows().stream()
+                .map(Stage.class::cast)
+                .collect(
+                    Collectors.collectingAndThen(toList(), FXCollections::observableArrayList)
+                );
+            logger(ApplicationStages.class).debug("successfully retrieved JavaFX stages by calling javafx.stage.Window.getWindows()");
             return stages;
         } catch (Exception e) {
-            logger(ApplicationStages.class).error("cannot observe stages changes by calling com.sun.javafx.stage.StageHelper.getStages()", e);
+            logger(ApplicationStages.class).error("cannot observe stages changes by calling javafx.stage.Window.getWindows()", e);
         }
         return FXCollections.emptyObservableList();
     }


### PR DESCRIPTION
In Java 9+, the method in `com.sun.javafx.stage.StageHelper.getStages()` got removed, which breaks CSSFX. However, in Java 9+ there is a method in `javafx.stage.Window.getWindows()` which returns all Windows, which can then be cast into a `Stage` (since `Stage extends Window`, this is not problematic).
I changed the call so it works with Java 9+. Maybe you could consider making a separate branch for Java 9+, I will then change the target to that branch, then you can release a separate version for Java 9, since `Window.getWindows()` is not available in Java 8.