### PR TITLE
Fixed Gradle Support

### DIFF
--- a/src/main/java/org/fxmisc/cssfx/impl/URIToPathConverters.java
+++ b/src/main/java/org/fxmisc/cssfx/impl/URIToPathConverters.java
@@ -78,11 +78,11 @@ public class URIToPathConverters {
         @Override
         public Path convert(String uri) {
             if (uri != null && uri.startsWith("file:")) {
-                if (uri.contains("build/classes/main")) {
+                if (uri.contains("build/resources/main")) {
                     String[] classesTransform = {
                             "src/main/java", "src/main/resources" };
                     for (String ct : classesTransform) {
-                        String potentialSourceURI = uri.replace("target/classes", ct);
+                        String potentialSourceURI = uri.replace("build/resources/main", ct);
                         try {
                             Path p = Paths.get(new URI(potentialSourceURI));
                             if (Files.exists(p)) {
@@ -92,11 +92,11 @@ public class URIToPathConverters {
                             e.printStackTrace();
                         }
                     }
-                } else if (uri.contains("build/classes/test")) {
+                } else if (uri.contains("build/resources/test")) {
                     String[] testClassesTransform = {
                             "src/test/java", "src/test/resources" };
                     for (String tct : testClassesTransform) {
-                        String potentialSourceURI = uri.replace("target/test-classes", tct);
+                        String potentialSourceURI = uri.replace("build/resources/test", tct);
                         try {
                             Path p = Paths.get(new URI(potentialSourceURI));
                             if (Files.exists(p)) {
@@ -113,6 +113,7 @@ public class URIToPathConverters {
             return null;
         }
     };
+
 
     private static Pattern[] JAR_PATTERNS = {
             Pattern.compile("jar:file:/(.*)/target/(.*)\\.jar!/(.*\\.css)") // resource from maven jar in target directory

--- a/src/main/java/org/fxmisc/cssfx/impl/URIToPathConverters.java
+++ b/src/main/java/org/fxmisc/cssfx/impl/URIToPathConverters.java
@@ -115,6 +115,47 @@ public class URIToPathConverters {
     };
 
 
+    private static final URIToPathConverter INTELLIJ_RESOURCE = new URIToPathConverter() {
+        @Override
+        public Path convert(String uri) {
+            if (uri != null && uri.startsWith("file:")) {
+                if (uri.contains("out/production/resources")) {
+                    String[] classesTransform = {
+                            "src/main/java", "src/main/resources" };
+                    for (String ct : classesTransform) {
+                        String potentialSourceURI = uri.replace("out/production/resources", ct);
+                        try {
+                            Path p = Paths.get(new URI(potentialSourceURI));
+                            if (Files.exists(p)) {
+                                return p;
+                            }
+                        } catch (URISyntaxException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                } else if (uri.contains("out/test/resources")) {
+                    String[] testClassesTransform = {
+                            "src/test/java", "src/test/resources" };
+                    for (String tct : testClassesTransform) {
+                        String potentialSourceURI = uri.replace("out/test/resources", tct);
+                        try {
+                            Path p = Paths.get(new URI(potentialSourceURI));
+                            if (Files.exists(p)) {
+                                return p;
+                            }
+                        } catch (URISyntaxException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+
+            logger(URIToPathConverters.class).debug("GRADLE converter failed to map css[%s] to a source file", uri);
+            return null;
+        }
+    };
+
+
     private static Pattern[] JAR_PATTERNS = {
             Pattern.compile("jar:file:/(.*)/target/(.*)\\.jar!/(.*\\.css)") // resource from maven jar in target directory
             , Pattern.compile("jar:file:/(.*)/build/(.*)\\.jar!/(.*\\.css)") // resource from gradle jar in target directory
@@ -152,5 +193,6 @@ public class URIToPathConverters {
             MAVEN_RESOURCE
             , GRADLE_RESOURCE
             , JAR_RESOURCE
+            , INTELLIJ_RESOURCE
     };
 }

--- a/src/main/java/org/fxmisc/cssfx/impl/monitoring/PathsWatcher.java
+++ b/src/main/java/org/fxmisc/cssfx/impl/monitoring/PathsWatcher.java
@@ -20,6 +20,8 @@ package org.fxmisc.cssfx.impl.monitoring;
  * #L%
  */
 
+import com.sun.nio.file.SensitivityWatchEventModifier;
+
 import static org.fxmisc.cssfx.impl.log.CSSFXLogger.logger;
 
 import java.io.IOException;
@@ -53,7 +55,7 @@ public class PathsWatcher {
             Map<String, List<Runnable>> fileAction = filesActions.computeIfAbsent(
                     directory.toString(), (p) -> {
                         try {
-                            directory.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+                            directory.register(watchService, new WatchEvent.Kind[]{StandardWatchEventKinds.ENTRY_MODIFY}, SensitivityWatchEventModifier.HIGH);
                         } catch (Exception e) {
                             e.printStackTrace();
                         }


### PR DESCRIPTION
This pull request fixes the support for Gradle.
Probably, the old version never worked properly.
With this change, cssfx should work fine with the latest version of Gradle.

It also works with javafx11 for me.

I've published it in my repository, so it can be used by everyone.
Here is a snipped, on how to use it:
```
repositories {
  jcenter()

  maven {
    url "http://sandec.bintray.com/repo"
  }
}
dependencies {
  compile 'de.sandec.cssfx:cssfx:1.0.4'
}
```
