### PR TITLE
#24 and #22 - Fixing exponential growth

### DIFF
--- a/src/main/java/org/fxmisc/cssfx/impl/CSSFXMonitor.java
+++ b/src/main/java/org/fxmisc/cssfx/impl/CSSFXMonitor.java
@@ -337,6 +337,9 @@ public class CSSFXMonitor {
                         Runnable r = new URIStyleUpdater(uri, sourceFile.toUri().toString(), (ObservableList<String>) stylesheets);
                         wp.monitor(directory.toAbsolutePath().normalize(), sourceFile.toAbsolutePath().normalize(), r);
                         runnables.add(r);
+                        Platform.runLater(() -> {
+                            r.run();
+                        });
 
                         sourceURIs.put(sourceFile.toUri().toString(), sourceFile);
                     }

--- a/src/main/java/org/fxmisc/cssfx/impl/events/CSSFXEvent.java
+++ b/src/main/java/org/fxmisc/cssfx/impl/events/CSSFXEvent.java
@@ -27,13 +27,9 @@ public final class CSSFXEvent<T> {
     
     public static enum EventType {
         STYLESHEET_ADDED
-        , STYLESHEET_REMOVED
         , NODE_ADDED
-        , NODE_REMOVED
         , SCENE_ADDED
-        , SCENE_REMOVED
         , STAGE_ADDED
-        , STAGE_REMOVED
     }
     
     private  CSSFXEvent(EventType type, T data) {


### PR DESCRIPTION
#24
I Rewrote the "monitoring code" in CSSFXMonitor.
previously listeners were created exponentially - leading to slowdowns and potential crashes.
The new Code makes sure, that each Scene/Window/Node is monitored only once.
I've removed the unregister methods and events because they weren't doing anything useful.

I'm using WeakHashMaps as WeakHashSet, because I don't want to add a new dependency to the project.

I've also fixed #22.

