### PR TITLE
Same URL can now be added to the same list and classpaths are now supported.

### DIFF
--- a/src/main/java/org/fxmisc/cssfx/impl/CSSFXMonitor.java
+++ b/src/main/java/org/fxmisc/cssfx/impl/CSSFXMonitor.java
@@ -466,18 +466,17 @@ public class CSSFXMonitor {
                     int counter = 0;
                     while(counter < cssURIs.size()) {
                         String v = cssURIs.get(counter);
-                        if(v == originalURI || v == sourceURI) {
+                        if(v.equals(originalURI) || v.equals(sourceURI)) {
                             cssURIs.remove(counter);
                             cssURIs.add(counter, sourceURI);
                         }
                         counter += 1;
                     }
                 };
-                if (Platform.isFxApplicationThread()) {
-                    task.run();
-                } else {
-                    Platform.runLater(task);
-                }
+                // It's important that we are using runLater even when we are using the JavaFX Thread.
+                // This way we make sure we are currently not running the ChangeListener
+                // which would result in an Exception.
+                Platform.runLater(task);
             }
         }
     }

--- a/src/main/java/org/fxmisc/cssfx/impl/CSSFXMonitor.java
+++ b/src/main/java/org/fxmisc/cssfx/impl/CSSFXMonitor.java
@@ -430,33 +430,24 @@ public class CSSFXMonitor {
 
         @Override
         public void run() {
-            IntegerProperty positionIndex = new SimpleIntegerProperty();
             ObservableList<String> cssURIs = cssURIsWeak.get();
 
             if(cssURIs != null) {
-                Runnable remover = () -> {
-                    positionIndex.set(cssURIs.indexOf(originalURI));
-                    if (positionIndex.get() != -1) {
-                        cssURIs.remove(originalURI);
-                    }
-                    if (positionIndex.get() == -1) {
-                        positionIndex.set(cssURIs.indexOf(sourceURI));
-                    }
-                    cssURIs.remove(sourceURI);
-                };
-                Runnable adder = () -> {
-                    if (positionIndex.get() >= 0) {
-                        cssURIs.add(positionIndex.get(), sourceURI);
-                    } else {
-                        cssURIs.add(sourceURI);
+                Runnable task = () -> {
+                    int counter = 0;
+                    while(counter < cssURIs.size()) {
+                        String v = cssURIs.get(counter);
+                        if(v == originalURI || v == sourceURI) {
+                            cssURIs.remove(counter);
+                            cssURIs.add(counter, sourceURI);
+                        }
+                        counter += 1;
                     }
                 };
                 if (Platform.isFxApplicationThread()) {
-                    remover.run();
-                    adder.run();
+                    task.run();
                 } else {
-                    Platform.runLater(remover);
-                    Platform.runLater(adder);
+                    Platform.runLater(task);
                 }
             }
         }

--- a/src/test/java/org/fxmisc/cssfx/test/TestCSSFXMonitor.java
+++ b/src/test/java/org/fxmisc/cssfx/test/TestCSSFXMonitor.java
@@ -74,25 +74,29 @@ public class TestCSSFXMonitor {
     public void testAddingTwice() throws Exception {
         CountDownLatch latch2 = new CountDownLatch(1);
         Platform.runLater(() -> {
-            Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-                @Override
-                public void uncaughtException(Thread thread, Throwable throwable) {
-                    throw new RuntimeException(throwable);
-                }
-            });
-            ObservableList<String> list = FXCollections.observableArrayList();
-            String uri = getClass().getResource("bottom.css").toExternalForm();
+            try {
+                Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                    @Override
+                    public void uncaughtException(Thread thread, Throwable throwable) {
+                        throw new RuntimeException(throwable);
+                    }
+                });
+                ObservableList<String> list = FXCollections.observableArrayList();
+                String uri = getClass().getResource("bottom.css").toExternalForm();
 
-            list.add(uri);
-            CSSFXMonitor monitor = new CSSFXMonitor();
-            monitor.addAllConverters(converters);
-            monitor.start();
-            monitor.monitorStylesheets(list);
-            list.add(uri);
-            list.add(uri);
-            latch2.countDown();
+                list.add(uri);
+                CSSFXMonitor monitor = new CSSFXMonitor();
+                monitor.addAllConverters(converters);
+                monitor.start();
+                monitor.monitorStylesheets(list);
+                list.add(uri);
+                list.add(uri);
+                latch2.countDown();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         });
-        if(!latch2.await(1, TimeUnit.SECONDS)) {
+        if(!latch2.await(100, TimeUnit.SECONDS)) {
             throw new Exception("Test Failed!");
         }
     }
@@ -102,26 +106,35 @@ public class TestCSSFXMonitor {
         ObservableList<String> list = FXCollections.observableArrayList();
         CountDownLatch latch2 = new CountDownLatch(1);
         Platform.runLater(() -> {
-            Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-                @Override
-                public void uncaughtException(Thread thread, Throwable throwable) {
-                    throw new RuntimeException(throwable);
-                }
-            });
-            String uri = getClass().getResource("bottom.css").toExternalForm();
-            CSSFXMonitor monitor = new CSSFXMonitor();
-            monitor.addAllConverters(converters);
-            monitor.start();
-            monitor.monitorStylesheets(list);
-            list.add(uri);
-            list.add("/org/fxmisc/cssfx/test/bottom.css");
+            try {
+                Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                    @Override
+                    public void uncaughtException(Thread thread, Throwable throwable) {
+                        throw new RuntimeException(throwable);
+                    }
+                });
+                String uri = getClass().getResource("bottom.css").toExternalForm();
+                CSSFXMonitor monitor = new CSSFXMonitor();
+                monitor.addAllConverters(converters);
+                monitor.start();
+                monitor.monitorStylesheets(list);
+                list.add(uri);
+                list.add("/org/fxmisc/cssfx/test/bottom.css");
 
-            System.out.println("list: " + list);
-            latch2.countDown();
+                System.out.println("list: " + list);
+                latch2.countDown();
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
+            }
         });
         if(!latch2.await(1, TimeUnit.SECONDS)) {
             throw new Exception("Test Failed!");
         }
+        // We have to wait another time, because we have to wait for another scheduled runLater.
+        CountDownLatch latch3 = new CountDownLatch(1);
+        Platform.runLater(() -> latch3.countDown());
+        latch3.await(1, TimeUnit.SECONDS);
         if(!list.get(0).equals(list.get(1))) {
             throw new RuntimeException("ClassPath wasn't properly converted to URI");
         }

--- a/src/test/java/org/fxmisc/cssfx/test/TestCSSFXMonitor.java
+++ b/src/test/java/org/fxmisc/cssfx/test/TestCSSFXMonitor.java
@@ -97,4 +97,34 @@ public class TestCSSFXMonitor {
         }
     }
 
+    @Test
+    public void testClasspathResource() throws Exception {
+        ObservableList<String> list = FXCollections.observableArrayList();
+        CountDownLatch latch2 = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                @Override
+                public void uncaughtException(Thread thread, Throwable throwable) {
+                    throw new RuntimeException(throwable);
+                }
+            });
+            String uri = getClass().getResource("bottom.css").toExternalForm();
+            CSSFXMonitor monitor = new CSSFXMonitor();
+            monitor.addAllConverters(converters);
+            monitor.start();
+            monitor.monitorStylesheets(list);
+            list.add(uri);
+            list.add("/org/fxmisc/cssfx/test/bottom.css");
+
+            System.out.println("list: " + list);
+            latch2.countDown();
+        });
+        if(!latch2.await(1, TimeUnit.SECONDS)) {
+            throw new Exception("Test Failed!");
+        }
+        if(!list.get(0).equals(list.get(1))) {
+            throw new RuntimeException("ClassPath wasn't properly converted to URI");
+        }
+    }
+
 }


### PR DESCRIPTION
I've noticed a race condition which only happened in the newest version.
It was caused by removing runLater when using the FX-Thread - which was not wrong - but it changed the timings slightly.
The underlying issue was, that adding the same URL can lead to an exception.
I've simplified the logic in the URIStyleUpdater which now supports the same URL twice.

I've also added support for specifying the stylesheet as a classpath.

Slightly offtopic,
can you do me a favor and mention somewhere https://www.jpro.one/ for providing/sponsoring the bugfixes I've provided?
We will also promote the library because in our opinion this library is mandatory for JavaFX to stay competitive with all the other UI-Frameworks. For that reason, every JavaFX Developer should start using it.